### PR TITLE
Correct IBM ThinkPad T41 Recovery CD download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ List of available IBM/Lenovo ThinkPad Recovery Media
 ### IBM ThinkPad T40
 | Model | OS | Language | Type | FRU | Link | Location | Additional Information |
 |--|--|--|--|--|--|--|--|
-| T40 | Windows XP Professional | English US | CD/DVD Image | 01R8046 | [Download](https://archive.org/details/IBMThinkpadT4041RecoveryCDs) | Archive.org |
+| T40 | Windows XP Professional | English US | CD/DVD Image | 01R8046 | [Download](c) | Archive.org |
 | T40 | Windows XP Professional | German | CD/DVD Image | 01R8051 | [Download](https://archive.org/details/t40_recovery_german) | Archive.org |
 
 ### IBM ThinkPad T41/T41p/R50/R50e/R50p
@@ -358,7 +358,7 @@ List of available IBM/Lenovo ThinkPad Recovery Media
 |--|--|--|--|--|--|--|--|
 | T41/R50 | Windows XP Professional | Chinese Simplified | CD/DVD Image | 01R8800 | [Download](https://archive.org/details/thinkpad-t41-t41p-t60-blueex_chsrecovery) | Archive.org |
 | T41/T41p/R50/R50p | Windows XP Professional | German | CD/DVD Image | 24R7067 | [Download](https://archive.org/details/24R7067) | Archive.org |
-| T41/T41p/R50/R50p | Windows XP Professional | English US | CD/DVD Image | 24R8116 | [Ask here](https://forum.thinkpads.com/viewtopic.php?t=128170) | Recovery Set Repository |
+| T41/T41p/R50/R50p | Windows XP Professional | English US | CD/DVD Image | 24R8116 | [Download](https://archive.org/details/IBMThinkpadT4041RecoveryCDs) | Archive.org |
 | R50e | Windows Home Edition | German | CD/DVD Image | | [Download](https://archive.org/details/TPR50eWINXPGR) | Archive.org | Create Recovery Media ISOs |
 
 ### IBM ThinkPad T42/T42p/R51


### PR DESCRIPTION
it must've been an oversight during compilation of the list, but the CD with the exact FRU number is available alongside the T40 Recovery CD.